### PR TITLE
Issue #35: High CPU Usage Due to Infinite Loop in IPMI Core library `Connection.run()`

### DIFF
--- a/src/main/java/org/sentrysoftware/ipmi/client/IpmiClient.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/IpmiClient.java
@@ -24,7 +24,6 @@ package org.sentrysoftware.ipmi.client;
 
 import static org.sentrysoftware.ipmi.client.Utils.execute;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -56,12 +55,9 @@ public class IpmiClient {
 	 */
 	public static GetChassisStatusResponseData getChassisStatus(final IpmiClientConfiguration ipmiConfiguration)
 			throws InterruptedException, ExecutionException, TimeoutException {
-		return execute(() -> {
-			try (GetChassisStatusRunner runner = new GetChassisStatusRunner(ipmiConfiguration)) {
-				runner.doRun();
-				return runner.getResult();
-			}
-		}, ipmiConfiguration.getTimeout() * 1000);
+		try (GetChassisStatusRunner runner = new GetChassisStatusRunner(ipmiConfiguration)){
+			return execute(runner, ipmiConfiguration.getTimeout() * 1000);
+		}
 	}
 
 	/**
@@ -76,13 +72,9 @@ public class IpmiClient {
 	 */
 	public static List<Sensor> getSensors(final IpmiClientConfiguration ipmiConfiguration)
 			throws InterruptedException, ExecutionException, TimeoutException {
-		return execute(() -> {
-			try (GetSensorsRunner runner = new GetSensorsRunner(ipmiConfiguration)) {
-				runner.doRun();
-				List<Sensor> result = runner.getResult();
-				return result != null ? result : new ArrayList<>();
-			}
-		}, ipmiConfiguration.getTimeout() * 1000);
+		try (GetSensorsRunner runner = new GetSensorsRunner(ipmiConfiguration)) {
+			return execute(runner, ipmiConfiguration.getTimeout() * 1000);
+		}
 	}
 
 	/**
@@ -97,13 +89,9 @@ public class IpmiClient {
 	 */
 	public static List<Fru> getFrus(final IpmiClientConfiguration ipmiConfiguration)
 			throws InterruptedException, ExecutionException, TimeoutException {
-		return execute(() -> {
-			try (GetFrusRunner runner = new GetFrusRunner(ipmiConfiguration)) {
-				runner.doRun();
-				List<Fru> result = runner.getResult();
-				return result != null ? result : new ArrayList<>();
-			}
-		}, ipmiConfiguration.getTimeout() * 1000);
+		try (GetFrusRunner runner = new GetFrusRunner(ipmiConfiguration)) {
+			return execute(runner, ipmiConfiguration.getTimeout() * 1000);
+		}
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
@@ -75,58 +75,138 @@ public class IpmiClientConfiguration {
 		this.pingPeriod = pingPeriod;
 	}
 
+	/**
+	 * Returns the IP Address or host name of the remote IPMI host.
+	 * 
+	 * @return IP Address or host name of the remote IPMI host.
+	 */
 	public String getHostname() {
 		return hostname;
 	}
 
+	/**
+	 * Sets the IP Address or host name of the remote IPMI host.
+	 * 
+	 * @param hostname IP Address or host name of the remote IPMI host.
+	 */
 	public void setHostname(String hostname) {
 		this.hostname = hostname;
 	}
 
+	/**
+	 * Returns the name used to establish the connection with the host via the IPMI
+	 * protocol.
+	 * 
+	 * @return Name used to establish the connection with the host via the IPMI protocol.
+	 */
 	public String getUsername() {
 		return username;
 	}
 
+	/**
+	 * Sets the name used to establish the connection with the host via the IPMI
+	 * protocol.
+	 * 
+	 * @param username Name used to establish the connection with the host via the
+	 *                 IPMI protocol.
+	 */
 	public void setUsername(String username) {
 		this.username = username;
 	}
 
+	/**
+	 * Returns the password used to establish the connection with the host via the
+	 * IPMI protocol.
+	 * 
+	 * @return Password used to establish the connection with the host via the IPMI protocol.
+	 */
 	public char[] getPassword() {
 		return password;
 	}
 
+	/**
+	 * Sets the password used to establish the connection with the host via the IPMI
+	 * protocol.
+	 * 
+	 * @param password Password used to establish the connection with the host via the IPMI protocol.
+	 */
 	public void setPassword(char[] password) {
 		this.password = password;
 	}
 
+	/**
+	 * Returns the key that should be provided if the two-key authentication is
+	 * enabled, null otherwise.
+	 * 
+	 * @return The key that should be provided if the two-key authentication is
+	 *         enabled, null otherwise.
+	 */
 	public byte[] getBmcKey() {
 		return bmcKey;
 	}
 
+	/**
+	 * Sets the key that should be provided if the two-key authentication is
+	 * enabled, null otherwise.
+	 * 
+	 * @param bmcKey The key that should be provided if the two-key authentication
+	 *               is enabled, null otherwise.
+	 */
 	public void setBmcKey(byte[] bmcKey) {
 		this.bmcKey = bmcKey;
 	}
 
+	/**
+	 * Returns whether the client should skip authentication.
+	 * 
+	 * @return Whether the client should skip authentication.
+	 */
 	public boolean isSkipAuth() {
 		return skipAuth;
 	}
 
+	/**
+	 * Sets whether the client should skip authentication.
+	 * 
+	 * @param skipAuth Whether the client should skip authentication.
+	 */
 	public void setSkipAuth(boolean skipAuth) {
 		this.skipAuth = skipAuth;
 	}
 
+	/**
+	 * Returns the timeout used for each IPMI request.
+	 * 
+	 * @return The timeout used for each IPMI request.
+	 */
 	public long getTimeout() {
 		return timeout;
 	}
 
+	/**
+	 * Sets the timeout used for each IPMI request.
+	 * 
+	 * @param timeout The timeout used for each IPMI request.
+	 */
 	public void setTimeout(long timeout) {
 		this.timeout = timeout;
 	}
 
+	/**
+	 * Returns the period in milliseconds used to send the keep alive messages.
+	 * 
+	 * @return The period in milliseconds used to send the keep alive messages.
+	 */
 	public long getPingPeriod() {
 		return pingPeriod;
 	}
 
+	/**
+	 * Sets the period in milliseconds used to send the keep alive messages.<br>
+	 * Set pingPeriod to 0 to turn off keep-alive messages sent to the remote host.
+	 * 
+	 * @param pingPeriod The period in milliseconds used to send the keep alive messages.
+	 */
 	public void setPingPeriod(long pingPeriod) {
 		this.pingPeriod = pingPeriod;
 	}

--- a/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
@@ -24,7 +24,7 @@ package org.sentrysoftware.ipmi.client;
 
 /**
  * IPMI configuration including the required credentials that need to be used to establish the
- * communication with the IPMI interface
+ * communication with the IPMI interface.
  *
  */
 public class IpmiClientConfiguration {
@@ -35,6 +35,7 @@ public class IpmiClientConfiguration {
 	private byte[] bmcKey;
 	private boolean skipAuth;
 	private long timeout;
+	private long pingPeriod = -1;
 
 	/**
 	 * Instantiates a new {@link IpmiClientConfiguration} in order to query the IPMI host.
@@ -54,6 +55,24 @@ public class IpmiClientConfiguration {
 		this.bmcKey = bmcKey;
 		this.skipAuth = skipAuth;
 		this.timeout = timeout;
+	}
+
+	/**
+	 * Instantiates a new {@link IpmiClientConfiguration} in order to query the IPMI host.
+	 * 
+	 * @param hostname   IP Address or host name of the remote IPMI host.
+	 * @param username   Name used to establish the connection with the host via the IPMI protocol.
+	 * @param password   Password used to establish the connection with the host via the IPMI protocol.
+	 * @param bmcKey     The key that should be provided if the two-key authentication is enabled, null otherwise.
+	 * @param skipAuth   Whether the client should skip authentication
+	 * @param timeout    Timeout used for each IPMI request.
+	 * @param pingPeriod The period in milliseconds used to send the keep alive messages.<br>
+	 *                   Set pingPeriod to 0 to turn off keep-alive messages sent to the remote host.
+	 */
+	public IpmiClientConfiguration(String hostname, String username, char[] password,
+			byte[] bmcKey, boolean skipAuth, long timeout, long pingPeriod) {
+		this(hostname, username, password, bmcKey, skipAuth, timeout);
+		this.pingPeriod = pingPeriod;
 	}
 
 	public String getHostname() {
@@ -102,6 +121,14 @@ public class IpmiClientConfiguration {
 
 	public void setTimeout(long timeout) {
 		this.timeout = timeout;
+	}
+
+	public long getPingPeriod() {
+		return pingPeriod;
+	}
+
+	public void setPingPeriod(long pingPeriod) {
+		this.pingPeriod = pingPeriod;
 	}
 
 }

--- a/src/main/java/org/sentrysoftware/ipmi/client/Utils.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/Utils.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.sentrysoftware.ipmi.client.runner.AbstractIpmiRunner;
+
 public class Utils {
 
 	private Utils() {}
@@ -81,7 +83,7 @@ public class Utils {
 	 * @throws ExecutionException
 	 * @throws TimeoutException
 	 */
-	public static <T> T execute(Callable<T> callable, long timeout)
+	public static <T> T execute(final AbstractIpmiRunner<T> callable, long timeout)
 			throws InterruptedException, ExecutionException, TimeoutException {
 
 		final ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/src/main/java/org/sentrysoftware/ipmi/client/runner/GetChassisStatusRunner.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/runner/GetChassisStatusRunner.java
@@ -38,15 +38,12 @@ public class GetChassisStatusRunner extends AbstractIpmiRunner<GetChassisStatusR
 	}
 
 	@Override
-	public void doRun() throws Exception {
-
+	public GetChassisStatusResponseData call() throws Exception {
 		super.startSession();
 
 		// Send the UDP message and read the response
-		GetChassisStatusResponseData rd = (GetChassisStatusResponseData) connector.sendMessage(handle,
+		return (GetChassisStatusResponseData) connector.sendMessage(handle,
 				new GetChassisStatus(IpmiVersion.V20, handle.getCipherSuite(), AuthenticationType.RMCPPlus));
-
-		super.setResult(rd);
 
 	}
 

--- a/src/main/java/org/sentrysoftware/ipmi/client/runner/GetFrusRunner.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/runner/GetFrusRunner.java
@@ -71,7 +71,7 @@ public class GetFrusRunner extends AbstractIpmiRunner<List<Fru>> {
 	}
 
 	@Override
-	public void doRun() throws Exception {
+	public List<Fru> call() throws Exception {
 		final List<Fru> result = new ArrayList<>();
 
 		super.startSession();
@@ -122,7 +122,7 @@ public class GetFrusRunner extends AbstractIpmiRunner<List<Fru>> {
 
 		}
 
-		super.setResult(result);
+		return result;
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/ipmi/client/runner/GetSensorsRunner.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/runner/GetSensorsRunner.java
@@ -57,7 +57,7 @@ public class GetSensorsRunner extends AbstractIpmiRunner<List<Sensor>> {
 	}
 
 	@Override
-	public void doRun() throws Exception {
+	public List<Sensor> call() throws Exception {
 
 		final List<Sensor> result = new ArrayList<>();
 
@@ -119,7 +119,7 @@ public class GetSensorsRunner extends AbstractIpmiRunner<List<Sensor>> {
 
 		}
 
-		super.setResult(result);
+		return result;
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/ipmi/core/api/async/IpmiAsyncConnector.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/api/async/IpmiAsyncConnector.java
@@ -131,7 +131,26 @@ public class IpmiAsyncConnector implements ConnectionListener {
         loadProperties();
     }
 
-    private void loadProperties() {
+	/**
+	 * Starts {@link IpmiAsyncConnector} and initiates the {@link ConnectionManager}
+	 * at the given port and ping period.
+	 * 
+	 * @param port       the port that will be used by {@link IpmiAsyncConnector} to
+	 *                   communicate with the remote hosts.
+	 * @param pingPeriod the period between sending keep-alive messages to the
+	 *                   remote host.
+	 * @throws IOException When ConnectionManager cannot be created due to an IO
+	 *                     error.
+	 */
+	public IpmiAsyncConnector(int port, long pingPeriod) throws IOException {
+		responseListeners = new ArrayList<>();
+		inboundMessageListeners = new ArrayList<>();
+		connectionManager = new ConnectionManager(port, pingPeriod);
+		sessionManager = new SessionManager();
+		loadProperties();
+	}
+
+	private void loadProperties() {
         retries = Integer.parseInt(PropertiesManager.getInstance().getProperty("retries"));
     }
 

--- a/src/main/java/org/sentrysoftware/ipmi/core/api/async/IpmiAsyncConnector.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/api/async/IpmiAsyncConnector.java
@@ -150,9 +150,12 @@ public class IpmiAsyncConnector implements ConnectionListener {
 		loadProperties();
 	}
 
+	/**
+	 * Loads properties from the properties file.
+	 */
 	private void loadProperties() {
-        retries = Integer.parseInt(PropertiesManager.getInstance().getProperty("retries"));
-    }
+		retries = Integer.parseInt(PropertiesManager.getInstance().getProperty("retries"));
+	}
 
     /**
      * Creates connection to the remote host.

--- a/src/main/java/org/sentrysoftware/ipmi/core/api/sync/IpmiConnector.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/api/sync/IpmiConnector.java
@@ -109,7 +109,20 @@ public class IpmiConnector {
         loadProperties();
     }
 
-    private void loadProperties() {
+    /**
+     * Starts {@link IpmiConnector} and initiates the {@link ConnectionManager} at the given port. Wildcard IP address
+     * will be used.
+     * <br>
+     * @param port       the port that will be used by {@link IpmiAsyncConnector} to communicate with the remote hosts.
+     * @param pingPeriod
+     * @throws IOException
+     */
+	public IpmiConnector(int port, long pingPeriod) throws IOException {
+		asyncConnector = new IpmiAsyncConnector(port, pingPeriod);
+		loadProperties();
+	}
+
+	private void loadProperties() {
         PropertiesManager manager = PropertiesManager.getInstance();
         retries = Integer.parseInt(manager.getProperty("retries"));
         idleTime = Integer.parseInt(manager.getProperty("idleTime"));

--- a/src/main/java/org/sentrysoftware/ipmi/core/api/sync/IpmiConnector.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/api/sync/IpmiConnector.java
@@ -109,24 +109,30 @@ public class IpmiConnector {
         loadProperties();
     }
 
-    /**
-     * Starts {@link IpmiConnector} and initiates the {@link ConnectionManager} at the given port. Wildcard IP address
-     * will be used.
-     * <br>
-     * @param port       the port that will be used by {@link IpmiAsyncConnector} to communicate with the remote hosts.
-     * @param pingPeriod
-     * @throws IOException
-     */
+	/**
+	 * Starts {@link IpmiConnector} and initiates the {@link ConnectionManager} at
+	 * the given port. Wildcard IP address will be used.
+	 * 
+	 * @param port       the port that will be used by {@link IpmiAsyncConnector} to
+	 *                   communicate with the remote hosts.
+	 * @param pingPeriod the period in milliseconds used to send the keep alive
+	 *                   messages.<br>
+	 *                   0 If keep-alive messages should be disabled.
+	 * @throws IOException When IpmiAsyncConnector cannot be created.
+	 */
 	public IpmiConnector(int port, long pingPeriod) throws IOException {
 		asyncConnector = new IpmiAsyncConnector(port, pingPeriod);
 		loadProperties();
 	}
 
+	/**
+	 * Loads properties from the properties file.
+	 */
 	private void loadProperties() {
-        PropertiesManager manager = PropertiesManager.getInstance();
-        retries = Integer.parseInt(manager.getProperty("retries"));
-        idleTime = Integer.parseInt(manager.getProperty("idleTime"));
-    }
+		PropertiesManager manager = PropertiesManager.getInstance();
+		retries = Integer.parseInt(manager.getProperty("retries"));
+		idleTime = Integer.parseInt(manager.getProperty("idleTime"));
+	}
 
     /**
      * Creates connection to the remote host on default IPMI port.

--- a/src/main/java/org/sentrysoftware/ipmi/core/connection/ConnectionManager.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/connection/ConnectionManager.java
@@ -49,15 +49,27 @@ public class ConnectionManager {
     /**
      * Frequency of the no-op commands that will be sent to keep up the session
      */
-    private static int pingPeriod = -1;
+    private long pingPeriod = -1;
+
+	/**
+	 * Initiates the connection manager. Wildcard IP address will be used.
+	 *
+	 * @param port       the port at which {@link UdpListener} will work
+	 * @param pingPeriod frequency of the no-op commands that will be sent to keep
+	 *                   up the session
+	 * @throws IOException If UdpMessenger encountered an error
+	 */
+	public ConnectionManager(int port, long pingPeriod) throws IOException {
+		this(port);
+		this.pingPeriod = pingPeriod;
+	}
 
     /**
      * Initiates the connection manager. Wildcard IP address will be used.
      *
      * @param port
      *            - the port at which {@link UdpListener} will work
-     * @throws IOException
-     *             when properties file was not found
+     * @throws IOException If UdpMessenger encountered an error
      */
     public ConnectionManager(int port) throws IOException {
         messenger = new UdpMessenger(port);
@@ -71,8 +83,7 @@ public class ConnectionManager {
      *            - the port at which {@link UdpListener} will work
      * @param address
      *            - the IP interface {@link UdpListener} will bind to
-     * @throws IOException
-     *             when properties file was not found
+     * @throws IOException If UdpMessenger encountered an error
      */
     public ConnectionManager(int port, InetAddress address) throws IOException {
         messenger = new UdpMessenger(port, address);
@@ -94,7 +105,7 @@ public class ConnectionManager {
         connections = new ArrayList<Connection>();
         reservedTags = new ArrayList<Integer>();
         if (pingPeriod == -1) {
-            pingPeriod = Integer.parseInt(PropertiesManager.getInstance().getProperty("pingPeriod"));
+            pingPeriod = Long.parseLong(PropertiesManager.getInstance().getProperty("pingPeriod"));
         }
     }
 

--- a/src/main/java/org/sentrysoftware/ipmi/core/connection/ConnectionManager.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/connection/ConnectionManager.java
@@ -56,7 +56,7 @@ public class ConnectionManager {
 	 *
 	 * @param port       the port at which {@link UdpListener} will work
 	 * @param pingPeriod frequency of the no-op commands that will be sent to keep
-	 *                   up the session
+	 *                   up the session. 0 to disable ping requests.
 	 * @throws IOException If UdpMessenger encountered an error
 	 */
 	public ConnectionManager(int port, long pingPeriod) throws IOException {

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -29,6 +29,8 @@ Invoke the IPMI Client:
 		final boolean noAuth = false;
 		final byte[] bmcKey = null;
 		final long timeout = 120;
+		// Set pingPeriod to 0 to turn off keep-alive messages sent to the remote host.
+		final pingPeriod = 30000;
 
 		// Instantiates a new IPMI client configuration using the credentials above
 		final IpmiClientConfiguration ipmiClientConfiguration = new IpmiClientConfiguration(


### PR DESCRIPTION
* Implemented the ability to override the `pingPeriod`, allowing it to be set to `0` to disable keep-alive messages.

* Added a delay (1 second) between retries to avoid tight looping and reduce CPU usage.

* Included a check for thread interruption to allow graceful shutdown.

* Modified the runner code to ensure that closable instances are properly closed.