### PR TITLE
Issue #46 : Add support for SHA-256 and MD5 authentication algorithms

### DIFF
--- a/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
@@ -1,8 +1,5 @@
 package org.sentrysoftware.ipmi.client;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client

--- a/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
+++ b/src/main/java/org/sentrysoftware/ipmi/client/IpmiClientConfiguration.java
@@ -1,5 +1,8 @@
 package org.sentrysoftware.ipmi.client;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
@@ -104,4 +104,9 @@ public abstract class AuthenticationAlgorithm {
      */
     public abstract boolean doIntegrityCheck(byte[] data, byte[] reference,
             byte[] sik) throws InvalidKeyException, NoSuchAlgorithmException;
+
+    /**
+     * @return the name of the algorithm as a {@code String}.
+     */
+    public abstract String getAlgorithmName();
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
@@ -43,7 +43,7 @@ public abstract class AuthenticationAlgorithm {
 	 * Constructs an authentication algorithm.
 	 */
 	protected AuthenticationAlgorithm(String algorithmName) {
-		this(newMacInstance(algorithmName));
+		this(CipherSuite.newMacInstance(algorithmName));
 	}
 
 	/**
@@ -53,23 +53,6 @@ public abstract class AuthenticationAlgorithm {
 	 */
 	private AuthenticationAlgorithm(Mac mac) {
 		this.mac = mac;
-	}
-
-	/**
-	 * Constructs a Mac object that implements the given MAC algorithm.
-	 *
-	 * @param algorithmName the name of the algorithm to use
-	 * @return The Mac object that implements the specified MAC algorithm.
-	 */
-	private static Mac newMacInstance(final String algorithmName) {
-		if (algorithmName == null || algorithmName.trim().isEmpty()) {
-			return null;
-		}
-		try {
-			return Mac.getInstance(algorithmName);
-		} catch (NoSuchAlgorithmException e) {
-			throw new IllegalArgumentException("Algorithm " + algorithmName + " is not available", e);
-		}
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationAlgorithm.java
@@ -24,6 +24,10 @@ package org.sentrysoftware.ipmi.core.coding.security;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.sentrysoftware.ipmi.core.coding.commands.session.Rakp1;
 
@@ -33,80 +37,105 @@ import org.sentrysoftware.ipmi.core.coding.commands.session.Rakp1;
  */
 public abstract class AuthenticationAlgorithm {
 
-    /**
-     * @return algorithm-specific code
-     */
-    public abstract byte getCode();
+	private final Mac mac;
 
-    /**
-     * @return length of the key for the RAKP2 message
-     */
-    public abstract int getKeyLength();
+	/**
+	 * Constructs an authentication algorithm
+	 *
+	 * @throws NoSuchAlgorithmException
+	 */
+	protected AuthenticationAlgorithm() throws NoSuchAlgorithmException {
+		this.mac = Mac.getInstance(getAlgorithmName());
+	}
 
-    /**
-     * @return length of the integrity check base for RAKP4 message
-     */
-    public abstract int getIntegrityCheckBaseLength();
+	/**
+	 * Constructs an authentication algorithm instance without initializing the MAC.
+	 *
+	 * @param noMacInit If {@code true}, the MAC instance will not be initialized.
+	 */
+	protected AuthenticationAlgorithm(boolean noMacInit) {
+		this.mac = null;
+	}
 
-    /**
-     * Checks value of the Key Exchange Authentication Code in RAKP messages
-     *
-     * @param data
-     *            - The base for authentication algorithm. Depends on RAKP
-     *            Message.
-     * @param key
-     *            - the Key Exchange Authentication Code to check.
-     * @param password
-     *            - password of the user establishing a session
-     * @return True if authentication check was successful, false otherwise.
-     * @throws NoSuchAlgorithmException
-     *             when initiation of the algorithm fails
-     * @throws InvalidKeyException
-     *             when creating of the algorithm key failsS
-     */
-    public abstract boolean checkKeyExchangeAuthenticationCode(byte[] data,
-            byte[] key, String password) throws NoSuchAlgorithmException,
-            InvalidKeyException;
+	/**
+	 * @return algorithm-specific code
+	 */
+	public abstract byte getCode();
 
-    /**
-     * Calculates value of the Key Exchange Authentication Code in RAKP messages
-     *
-     * @param data
-     *            - The base for authentication algorithm. Depends on RAKP
-     *            Message.
-     * @param password
-     *            - password of the user establishing a session
-     * @throws NoSuchAlgorithmException
-     *             when initiation of the algorithm fails
-     * @throws InvalidKeyException
-     *             when creating of the algorithm key fails
-     */
-    public abstract byte[] getKeyExchangeAuthenticationCode(byte[] data,
-            String password) throws NoSuchAlgorithmException,
-            InvalidKeyException;
+	/**
+	 * @return length of the key for the RAKP2 message
+	 */
+	public abstract int getKeyLength();
 
-    /**
-     * Validates Integrity Check Value in RAKP Message 4.
-     *
-     * @param data
-     *            - The base for authentication algorithm.
-     * @param reference
-     *            - The Integrity Check Value to validate.
-     * @param sik
-     *            - The Session Integrity Key generated on base of RAKP Messages
-     *            1 and 2.
-     * @see Rakp1#calculateSik(org.sentrysoftware.ipmi.core.coding.commands.session.Rakp1ResponseData)
-     * @return True if integrity check was successful, false otherwise.
-     * @throws NoSuchAlgorithmException
-     *             when initiation of the algorithm fails
-     * @throws InvalidKeyException
-     *             when creating of the algorithm key fails
-     */
-    public abstract boolean doIntegrityCheck(byte[] data, byte[] reference,
-            byte[] sik) throws InvalidKeyException, NoSuchAlgorithmException;
+	/**
+	 * @return length of the integrity check base for RAKP4 message
+	 */
+	public abstract int getIntegrityCheckBaseLength();
 
-    /**
-     * @return the name of the algorithm as a {@code String}.
-     */
-    public abstract String getAlgorithmName();
+	/**
+	 * Checks value of the Key Exchange Authentication Code in RAKP messages
+	 *
+	 * @param data     - The base for authentication algorithm. Depends on RAKP
+	 *                 Message.
+	 * @param key      - the Key Exchange Authentication Code to check.
+	 * @param password - password of the user establishing a session
+	 * @return True if authentication check was successful, false otherwise.
+	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
+	 * @throws InvalidKeyException      when creating of the algorithm key fails
+	 */
+	public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password)
+			throws NoSuchAlgorithmException, InvalidKeyException {
+		byte[] check = getKeyExchangeAuthenticationCode(data, password);
+		return Arrays.equals(check, key);
+	}
+
+	/**
+	 * Calculates value of the Key Exchange Authentication Code in RAKP messages
+	 *
+	 * @param data     - The base for authentication algorithm. Depends on RAKP
+	 *                 Message.
+	 * @param password - password of the user establishing a session
+	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
+	 * @throws InvalidKeyException      when creating of the algorithm key fails
+	 */
+	public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password)
+			throws NoSuchAlgorithmException, InvalidKeyException {
+
+		byte[] key = password.getBytes();
+
+		SecretKeySpec sKey = new SecretKeySpec(key, getAlgorithmName());
+		mac.init(sKey);
+
+		return mac.doFinal(data);
+	}
+
+	/**
+	 * Validates Integrity Check Value in RAKP Message 4.
+	 *
+	 * @param data      - The base for authentication algorithm.
+	 * @param reference - The Integrity Check Value to validate.
+	 * @param sik       - The Session Integrity Key generated on base of RAKP
+	 *                  Messages 1 and 2.
+	 * @see Rakp1#calculateSik(org.sentrysoftware.ipmi.core.coding.commands.session.Rakp1ResponseData)
+	 * @return True if integrity check was successful, false otherwise.
+	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
+	 * @throws InvalidKeyException      when creating of the algorithm key fails
+	 */
+	public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik)
+			throws InvalidKeyException, NoSuchAlgorithmException {
+
+		SecretKeySpec sKey = new SecretKeySpec(sik, getAlgorithmName());
+		mac.init(sKey);
+
+		byte[] result = new byte[getIntegrityCheckBaseLength()];
+
+		System.arraycopy(mac.doFinal(data), 0, result, 0, getIntegrityCheckBaseLength());
+
+		return Arrays.equals(result, reference);
+	}
+
+	/**
+	 * @return the name of the algorithm as a {@code String}.
+	 */
+	public abstract String getAlgorithmName();
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
@@ -29,40 +29,39 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-/**
- * RAKP-HMAC-SHA1 authentication algorithm.
- */
-public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
 
-    private static final String ALGORITHM_NAME = "HmacSHA1";
+/**
+ * RAKP-HMAC-MD5 authentication algorithm.
+ */
+public class AuthenticationRakpHmacMd5 extends AuthenticationAlgorithm {
+
+    private static final String ALGORITHM_NAME = "HmacMD5";
 
     private Mac mac;
 
-    /**
-     * Initiates RAKP-HMAC-SHA1 authentication algorithm.
-     * @throws NoSuchAlgorithmException
-     *             - when initiation of the algorithm fails
-     */
-    public AuthenticationRakpHmacSha1() throws NoSuchAlgorithmException {
+	/**
+	 * Initiates RAKP-HMAC-MD5 authentication algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
+	 */
+    public AuthenticationRakpHmacMd5() throws NoSuchAlgorithmException {
         mac = Mac.getInstance(ALGORITHM_NAME);
     }
 
     @Override
     public byte getCode() {
-        return SecurityConstants.AA_RAKP_HMAC_SHA1;
+        return SecurityConstants.AA_RAKP_HMAC_MD5;
     }
 
     @Override
-    public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key,
-            String password) throws NoSuchAlgorithmException,
-            InvalidKeyException {
+    public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password)
+            throws NoSuchAlgorithmException, InvalidKeyException {
         byte[] check = getKeyExchangeAuthenticationCode(data, password);
         return Arrays.equals(check, key);
     }
 
     @Override
-    public byte[] getKeyExchangeAuthenticationCode(byte[] data,
-        String password)
+    public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password)
             throws NoSuchAlgorithmException, InvalidKeyException {
 
         byte[] key = password.getBytes();
@@ -74,7 +73,8 @@ public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
     }
 
     @Override
-    public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik) throws InvalidKeyException, NoSuchAlgorithmException {
+    public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik)
+            throws InvalidKeyException, NoSuchAlgorithmException {
 
         SecretKeySpec sKey = new SecretKeySpec(sik, ALGORITHM_NAME);
         mac.init(sKey);
@@ -88,7 +88,7 @@ public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
 
     @Override
     public int getKeyLength() {
-        return 20;
+        return 16;
     }
 
     @Override
@@ -97,7 +97,7 @@ public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
     }
 
     @Override
-    public String getAlgorithmName() {
+	public String getAlgorithmName() {
 		return ALGORITHM_NAME;
 	}
 

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
@@ -39,11 +39,11 @@ public class AuthenticationRakpHmacMd5 extends AuthenticationAlgorithm {
 
     private Mac mac;
 
-	/**
-	 * Initiates RAKP-HMAC-MD5 authentication algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
-	 */
+    /**
+     * Initiates RAKP-HMAC-MD5 authentication algorithm.
+     *
+     * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
+     */
     public AuthenticationRakpHmacMd5() throws NoSuchAlgorithmException {
         mac = Mac.getInstance(ALGORITHM_NAME);
     }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
@@ -33,11 +33,9 @@ public class AuthenticationRakpHmacMd5 extends AuthenticationAlgorithm {
 
 	/**
 	 * Initiates RAKP-HMAC-MD5 authentication algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
 	 */
-	public AuthenticationRakpHmacMd5() throws NoSuchAlgorithmException {
-		super();
+	public AuthenticationRakpHmacMd5() {
+		super(ALGORITHM_NAME);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * RAKP-HMAC-MD5 authentication algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacMd5.java
@@ -22,81 +22,40 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 
 /**
  * RAKP-HMAC-MD5 authentication algorithm.
  */
 public class AuthenticationRakpHmacMd5 extends AuthenticationAlgorithm {
 
-    private static final String ALGORITHM_NAME = "HmacMD5";
+	private static final String ALGORITHM_NAME = "HmacMD5";
 
-    private Mac mac;
+	/**
+	 * Initiates RAKP-HMAC-MD5 authentication algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
+	 */
+	public AuthenticationRakpHmacMd5() throws NoSuchAlgorithmException {
+		super();
+	}
 
-    /**
-     * Initiates RAKP-HMAC-MD5 authentication algorithm.
-     *
-     * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
-     */
-    public AuthenticationRakpHmacMd5() throws NoSuchAlgorithmException {
-        mac = Mac.getInstance(ALGORITHM_NAME);
-    }
+	@Override
+	public byte getCode() {
+		return SecurityConstants.AA_RAKP_HMAC_MD5;
+	}
 
-    @Override
-    public byte getCode() {
-        return SecurityConstants.AA_RAKP_HMAC_MD5;
-    }
+	@Override
+	public int getKeyLength() {
+		return 16;
+	}
 
-    @Override
-    public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password)
-            throws NoSuchAlgorithmException, InvalidKeyException {
-        byte[] check = getKeyExchangeAuthenticationCode(data, password);
-        return Arrays.equals(check, key);
-    }
+	@Override
+	public int getIntegrityCheckBaseLength() {
+		return 12;
+	}
 
-    @Override
-    public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password)
-            throws NoSuchAlgorithmException, InvalidKeyException {
-
-        byte[] key = password.getBytes();
-
-        SecretKeySpec sKey = new SecretKeySpec(key, ALGORITHM_NAME);
-        mac.init(sKey);
-
-        return mac.doFinal(data);
-    }
-
-    @Override
-    public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik)
-            throws InvalidKeyException, NoSuchAlgorithmException {
-
-        SecretKeySpec sKey = new SecretKeySpec(sik, ALGORITHM_NAME);
-        mac.init(sKey);
-
-        byte[] result = new byte[getIntegrityCheckBaseLength()];
-
-        System.arraycopy(mac.doFinal(data), 0, result, 0, getIntegrityCheckBaseLength());
-
-        return Arrays.equals(result, reference);
-    }
-
-    @Override
-    public int getKeyLength() {
-        return 16;
-    }
-
-    @Override
-    public int getIntegrityCheckBaseLength() {
-        return 12;
-    }
-
-    @Override
+	@Override
 	public String getAlgorithmName() {
 		return ALGORITHM_NAME;
 	}

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
@@ -28,17 +28,15 @@ import java.security.NoSuchAlgorithmException;
  * RAKP-HMAC-SHA1 authentication algorithm.
  */
 public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
-
+	
+	private static final String ALGORITHM_NAME = "HmacSHA1";
+	
 	/**
 	 * Initiates RAKP-HMAC-SHA1 authentication algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
 	 */
-	public AuthenticationRakpHmacSha1() throws NoSuchAlgorithmException {
-		super();
+	public AuthenticationRakpHmacSha1() {
+		super(ALGORITHM_NAME);
 	}
-
-	private static final String ALGORITHM_NAME = "HmacSHA1";
 
 	@Override
 	public byte getCode() {

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * RAKP-HMAC-SHA1 authentication algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha1.java
@@ -22,82 +22,41 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * RAKP-HMAC-SHA1 authentication algorithm.
  */
 public class AuthenticationRakpHmacSha1 extends AuthenticationAlgorithm {
 
-    private static final String ALGORITHM_NAME = "HmacSHA1";
+	/**
+	 * Initiates RAKP-HMAC-SHA1 authentication algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
+	 */
+	public AuthenticationRakpHmacSha1() throws NoSuchAlgorithmException {
+		super();
+	}
 
-    private Mac mac;
+	private static final String ALGORITHM_NAME = "HmacSHA1";
 
-    /**
-     * Initiates RAKP-HMAC-SHA1 authentication algorithm.
-     * @throws NoSuchAlgorithmException
-     *             - when initiation of the algorithm fails
-     */
-    public AuthenticationRakpHmacSha1() throws NoSuchAlgorithmException {
-        mac = Mac.getInstance(ALGORITHM_NAME);
-    }
+	@Override
+	public byte getCode() {
+		return SecurityConstants.AA_RAKP_HMAC_SHA1;
+	}
 
-    @Override
-    public byte getCode() {
-        return SecurityConstants.AA_RAKP_HMAC_SHA1;
-    }
+	@Override
+	public int getKeyLength() {
+		return 20;
+	}
 
-    @Override
-    public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key,
-            String password) throws NoSuchAlgorithmException,
-            InvalidKeyException {
-        byte[] check = getKeyExchangeAuthenticationCode(data, password);
-        return Arrays.equals(check, key);
-    }
+	@Override
+	public int getIntegrityCheckBaseLength() {
+		return 12;
+	}
 
-    @Override
-    public byte[] getKeyExchangeAuthenticationCode(byte[] data,
-        String password)
-            throws NoSuchAlgorithmException, InvalidKeyException {
-
-        byte[] key = password.getBytes();
-
-        SecretKeySpec sKey = new SecretKeySpec(key, ALGORITHM_NAME);
-        mac.init(sKey);
-
-        return mac.doFinal(data);
-    }
-
-    @Override
-    public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik) throws InvalidKeyException, NoSuchAlgorithmException {
-
-        SecretKeySpec sKey = new SecretKeySpec(sik, ALGORITHM_NAME);
-        mac.init(sKey);
-
-        byte[] result = new byte[getIntegrityCheckBaseLength()];
-
-        System.arraycopy(mac.doFinal(data), 0, result, 0, getIntegrityCheckBaseLength());
-
-        return Arrays.equals(result, reference);
-    }
-
-    @Override
-    public int getKeyLength() {
-        return 20;
-    }
-
-    @Override
-    public int getIntegrityCheckBaseLength() {
-        return 12;
-    }
-
-    @Override
-    public String getAlgorithmName() {
+	@Override
+	public String getAlgorithmName() {
 		return ALGORITHM_NAME;
 	}
 

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * RAKP-HMAC-SHA256 authentication algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
@@ -33,11 +33,9 @@ public class AuthenticationRakpHmacSha256 extends AuthenticationAlgorithm {
 
 	/**
 	 * Initiates RAKP-HMAC-SHA256 authentication algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
 	 */
-	public AuthenticationRakpHmacSha256() throws NoSuchAlgorithmException {
-		super();
+	public AuthenticationRakpHmacSha256() {
+		super(ALGORITHM_NAME);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
@@ -22,12 +22,7 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * RAKP-HMAC-SHA256 authentication algorithm.
@@ -36,54 +31,18 @@ public class AuthenticationRakpHmacSha256 extends AuthenticationAlgorithm {
 
 	private static final String ALGORITHM_NAME = "HmacSHA256";
 
-	private Mac mac;
-
 	/**
 	 * Initiates RAKP-HMAC-SHA256 authentication algorithm.
 	 *
-	 * @throws NoSuchAlgorithmException
-	 * 			   - when initiation of the algorithm fails
+	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
 	 */
 	public AuthenticationRakpHmacSha256() throws NoSuchAlgorithmException {
-		mac = Mac.getInstance(ALGORITHM_NAME);
+		super();
 	}
 
 	@Override
 	public byte getCode() {
 		return SecurityConstants.AA_RAKP_HMAC_SHA256;
-	}
-
-	@Override
-	public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password)
-			throws NoSuchAlgorithmException, InvalidKeyException {
-		byte[] check = getKeyExchangeAuthenticationCode(data, password);
-		return Arrays.equals(check, key);
-	}
-
-	@Override
-	public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password)
-			throws NoSuchAlgorithmException, InvalidKeyException {
-
-		byte[] key = password.getBytes();
-
-		SecretKeySpec sKey = new SecretKeySpec(key, ALGORITHM_NAME);
-		mac.init(sKey);
-
-		return mac.doFinal(data);
-	}
-
-	@Override
-	public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik)
-			throws InvalidKeyException, NoSuchAlgorithmException {
-
-		SecretKeySpec sKey = new SecretKeySpec(sik, ALGORITHM_NAME);
-		mac.init(sKey);
-
-		byte[] result = new byte[getIntegrityCheckBaseLength()];
-
-		System.arraycopy(mac.doFinal(data), 0, result, 0, getIntegrityCheckBaseLength());
-
-		return Arrays.equals(result, reference);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpHmacSha256.java
@@ -1,0 +1,104 @@
+package org.sentrysoftware.ipmi.core.coding.security;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * IPMI Java Client
+ * ჻჻჻჻჻჻
+ * Copyright 2023 Verax Systems, Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * RAKP-HMAC-SHA256 authentication algorithm.
+ */
+public class AuthenticationRakpHmacSha256 extends AuthenticationAlgorithm {
+
+	private static final String ALGORITHM_NAME = "HmacSHA256";
+
+	private Mac mac;
+
+	/**
+	 * Initiates RAKP-HMAC-SHA256 authentication algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException
+	 * 			   - when initiation of the algorithm fails
+	 */
+	public AuthenticationRakpHmacSha256() throws NoSuchAlgorithmException {
+		mac = Mac.getInstance(ALGORITHM_NAME);
+	}
+
+	@Override
+	public byte getCode() {
+		return SecurityConstants.AA_RAKP_HMAC_SHA256;
+	}
+
+	@Override
+	public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password)
+			throws NoSuchAlgorithmException, InvalidKeyException {
+		byte[] check = getKeyExchangeAuthenticationCode(data, password);
+		return Arrays.equals(check, key);
+	}
+
+	@Override
+	public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password)
+			throws NoSuchAlgorithmException, InvalidKeyException {
+
+		byte[] key = password.getBytes();
+
+		SecretKeySpec sKey = new SecretKeySpec(key, ALGORITHM_NAME);
+		mac.init(sKey);
+
+		return mac.doFinal(data);
+	}
+
+	@Override
+	public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik)
+			throws InvalidKeyException, NoSuchAlgorithmException {
+
+		SecretKeySpec sKey = new SecretKeySpec(sik, ALGORITHM_NAME);
+		mac.init(sKey);
+
+		byte[] result = new byte[getIntegrityCheckBaseLength()];
+
+		System.arraycopy(mac.doFinal(data), 0, result, 0, getIntegrityCheckBaseLength());
+
+		return Arrays.equals(result, reference);
+	}
+
+	@Override
+	public int getKeyLength() {
+		return 32;
+	}
+
+	@Override
+	public int getIntegrityCheckBaseLength() {
+		return 16;
+	}
+
+	@Override
+	public String getAlgorithmName() {
+		return ALGORITHM_NAME;
+	}
+
+}

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
@@ -70,4 +70,9 @@ public class AuthenticationRakpNone extends AuthenticationAlgorithm {
         return 0;
     }
 
+	@Override
+	public String getAlgorithmName() {
+		return "";
+	}
+
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
@@ -31,13 +31,9 @@ public class AuthenticationRakpNone extends AuthenticationAlgorithm {
 
 	/**
      * Constructs an instance of the RAKP-None authentication algorithm.
-     * 
-     * Since this algorithm does not require cryptographic operations, it uses 
-     * {@code super(true)} to skip MAC initialization in the parent class.
-     * 
      */
 	public AuthenticationRakpNone() {
-		super(true);
+		super("");
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
@@ -1,7 +1,5 @@
 package org.sentrysoftware.ipmi.core.coding.security;
 
-import java.security.NoSuchAlgorithmException;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/AuthenticationRakpNone.java
@@ -1,5 +1,7 @@
 package org.sentrysoftware.ipmi.core.coding.security;
 
+import java.security.NoSuchAlgorithmException;
+
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client
@@ -27,52 +29,60 @@ package org.sentrysoftware.ipmi.core.coding.security;
  */
 public class AuthenticationRakpNone extends AuthenticationAlgorithm {
 
-    @Override
-    public byte getCode() {
-        return SecurityConstants.AA_RAKP_NONE;
-    }
-
-    /**
-     * Checks value of the Key Exchange Authentication Code in RAKP messages
-     * using the RAKP-None algorithm.
+	/**
+     * Constructs an instance of the RAKP-None authentication algorithm.
+     * 
+     * Since this algorithm does not require cryptographic operations, it uses 
+     * {@code super(true)} to skip MAC initialization in the parent class.
+     * 
      */
-    @Override
-    public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password) {
-        return true;
-    }
+	public AuthenticationRakpNone() {
+		super(true);
+	}
 
-    /**
-     * Calculates value of the Key Exchange Authentication Code in RAKP messages
-     * using the RAKP-None algorithm.
-     */
-    @Override
-    public byte[] getKeyExchangeAuthenticationCode(byte[] data,
-            String password) {
-        return new byte[0];
-    }
+	@Override
+	public byte getCode() {
+		return SecurityConstants.AA_RAKP_NONE;
+	}
 
-    /**
-     * Performs Integrity Check in RAKP 4 message
-     * using the RAKP-None algorithm.
-     */
-    @Override
-    public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik) {
-        return true;
-    }
+	/**
+	 * Checks value of the Key Exchange Authentication Code in RAKP messages using
+	 * the RAKP-None algorithm.
+	 */
+	@Override
+	public boolean checkKeyExchangeAuthenticationCode(byte[] data, byte[] key, String password) {
+		return true;
+	}
 
-    @Override
-    public int getKeyLength() {
-        return 0;
-    }
+	/**
+	 * Calculates value of the Key Exchange Authentication Code in RAKP messages
+	 * using the RAKP-None algorithm.
+	 */
+	@Override
+	public byte[] getKeyExchangeAuthenticationCode(byte[] data, String password) {
+		return new byte[0];
+	}
 
-    @Override
-    public int getIntegrityCheckBaseLength() {
-        return 0;
-    }
+	/**
+	 * Performs Integrity Check in RAKP 4 message using the RAKP-None algorithm.
+	 */
+	@Override
+	public boolean doIntegrityCheck(byte[] data, byte[] reference, byte[] sik) {
+		return true;
+	}
+
+	@Override
+	public int getKeyLength() {
+		return 0;
+	}
+
+	@Override
+	public int getIntegrityCheckBaseLength() {
+		return 0;
+	}
 
 	@Override
 	public String getAlgorithmName() {
 		return "";
 	}
-
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
@@ -31,6 +31,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Provides cipher suite (authentication, confidentiality and integrity
@@ -81,64 +82,54 @@ public class CipherSuite {
         getConfidentialityAlgorithm().initialize(sik, getAuthenticationAlgorithm());
     }
 
-    /**
-     * Returns instance of AuthenticationAlgorithm class.
-     *
-     * @throws IllegalArgumentException
-     *             when authentication algorithm code is incorrect.
-     */
-    public AuthenticationAlgorithm getAuthenticationAlgorithm() {
-        if (aa != null && aa.getCode() != authenticationAlgorithm) {
-            throw new IllegalArgumentException(
-                    "Invalid authentication algorithm code");
-        }
-        switch (authenticationAlgorithm) {
-        case SecurityConstants.AA_RAKP_NONE:
-            if (aa == null) {
-                aa = new AuthenticationRakpNone();
-            }
-            return aa;
-        case SecurityConstants.AA_RAKP_HMAC_SHA1:
-            return instantiateRakpHmacSha1Algorithm();
-        case SecurityConstants.AA_RAKP_HMAC_MD5:
-            return instantiateRakpHmacMd5Algorithm();
-        case SecurityConstants.AA_RAKP_HMAC_SHA256:
-            return instantiateRakpHmacSha256Algorithm();
-        default:
-            throw new IllegalArgumentException("Invalid authentication algorithm.");
-        }
-    }
+	/**
+	 * Returns instance of AuthenticationAlgorithm class.
+	 *
+	 * @throws IllegalArgumentException when authentication algorithm code is
+	 *                                  incorrect.
+	 */
+	public AuthenticationAlgorithm getAuthenticationAlgorithm() {
+		if (aa != null && aa.getCode() != authenticationAlgorithm) {
+			throw new IllegalArgumentException("Invalid authentication algorithm code");
+		}
+		switch (authenticationAlgorithm) {
+		case SecurityConstants.AA_RAKP_NONE:
+			return instantiateAuthenticationAlgorithm(AuthenticationRakpNone::new);
+		case SecurityConstants.AA_RAKP_HMAC_SHA1:
+			return instantiateAuthenticationAlgorithm(AuthenticationRakpHmacSha1::new);
+		case SecurityConstants.AA_RAKP_HMAC_MD5:
+			return instantiateAuthenticationAlgorithm(AuthenticationRakpHmacMd5::new);
+		case SecurityConstants.AA_RAKP_HMAC_SHA256:
+			return instantiateAuthenticationAlgorithm(AuthenticationRakpHmacSha256::new);
+		default:
+			throw new IllegalArgumentException("Invalid authentication algorithm.");
+		}
+	}
 
-    /**
-     * Returns instance of IntegrityAlgorithm class.
-     *
-     * @throws IllegalArgumentException
-     *             when integrity algorithm code is incorrect.
-     */
-    public IntegrityAlgorithm getIntegrityAlgorithm(){
-        if (ia != null && ia.getCode() != integrityAlgorithm) {
-            throw new IllegalArgumentException(
-                    "Invalid integrity algorithm code");
-        }
-        switch (integrityAlgorithm) {
-        case SecurityConstants.IA_NONE:
-            if (ia == null) {
-                ia = new IntegrityNone();
-            }
-            return ia;
-        case SecurityConstants.IA_HMAC_SHA1_96:
-            return instantiateIntegrityHmacSha196Algorithm();
-        case SecurityConstants.IA_MD5_128:
-            // TODO: MD5-128
-        case SecurityConstants.IA_HMAC_MD5_128:
-            return instantiateIntegrityHmacMd5128Algorithm();
-        case SecurityConstants.IA_HMAC_SHA256_128:
-            return instantiateIntegrityHmacSha256128Algorithm();
-        default:
-            throw new IllegalArgumentException("Invalid integrity algorithm.");
-
-        }
-    }
+	/**
+	 * Returns instance of IntegrityAlgorithm class.
+	 *
+	 * @throws IllegalArgumentException when integrity algorithm code is incorrect.
+	 */
+	public IntegrityAlgorithm getIntegrityAlgorithm() {
+		if (ia != null && ia.getCode() != integrityAlgorithm) {
+			throw new IllegalArgumentException("Invalid integrity algorithm code");
+		}
+		switch (integrityAlgorithm) {
+		case SecurityConstants.IA_NONE:
+			return instantiateIntegrityAlgorithm(IntegrityNone::new);
+		case SecurityConstants.IA_HMAC_SHA1_96:
+			return instantiateIntegrityAlgorithm(IntegrityHmacSha1_96::new);
+		case SecurityConstants.IA_MD5_128:
+			// TODO: MD5-128
+		case SecurityConstants.IA_HMAC_MD5_128:
+			return instantiateIntegrityAlgorithm(IntegrityHmacMd5_128::new);
+		case SecurityConstants.IA_HMAC_SHA256_128:
+			return instantiateIntegrityAlgorithm(IntegrityHmacSha256_128::new);
+		default:
+			throw new IllegalArgumentException("Invalid integrity algorithm.");
+		}
+	}
 
     /**
      * Returns instance of ConfidentialityAlgorithm class.
@@ -231,104 +222,28 @@ public class CipherSuite {
     }
 
 	/**
-	 * Creates an instance of AuthenticationRakpHmacSha1.
+	 * Creates an instance of AuthenticationAlgorithm.
 	 *
-	 * @return An instance of {@code AuthenticationRakpHmacSha1}.
-	 * @throws IllegalArgumentException if algorithm initialization fails.
+	 * @param supplier constructor of the algorithm
 	 */
-	private AuthenticationAlgorithm instantiateRakpHmacSha1Algorithm() {
+	private AuthenticationAlgorithm instantiateAuthenticationAlgorithm(
+			final Supplier<AuthenticationAlgorithm> constructor) {
 		if (aa == null) {
-			try {
-				aa = new AuthenticationRakpHmacSha1();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
+			aa = constructor.get();
 		}
 		return aa;
 	}
-
+	
 	/**
-	 * Creates an instance of AuthenticationRakpHmacMd5.
+	 * Creates an instance of IntegrityAlgorithm.
 	 *
-	 * @return An instance of {@code AuthenticationRakpHmacMd5}.
-	 * @throws IllegalArgumentException if algorithm initialization fails.
+	 * @param supplier constructor of the algorithm
 	 */
-	private AuthenticationAlgorithm instantiateRakpHmacMd5Algorithm() {
-		if (aa == null) {
-			try {
-				aa = new AuthenticationRakpHmacMd5();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
-		}
-		return aa;
-	}
-
-	/**
-	 * Creates an instance of AuthenticationRakpHmacSha256.
-	 *
-	 * @return An instance of {@code AuthenticationRakpHmacSha256}.
-	 * @throws IllegalArgumentException if algorithm initialization fails.
-	 */
-	private AuthenticationAlgorithm instantiateRakpHmacSha256Algorithm() {
-		if (aa == null) {
-			try {
-				aa = new AuthenticationRakpHmacSha256();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
-		}
-		return aa;
-	}
-
-	/**
-	 * Creates an instance of IntegrityHmacSha1_96.
-	 *
-	 * @return An instance of {@code IntegrityHmacSha1_96}.
-	 * @throws IllegalArgumentException if the algorithm initiation fails.
-	 */
-	private IntegrityAlgorithm instantiateIntegrityHmacSha196Algorithm() {
+	private IntegrityAlgorithm instantiateIntegrityAlgorithm(final Supplier<IntegrityAlgorithm> constructor) {
 		if (ia == null) {
-			try {
-				ia = new IntegrityHmacSha1_96();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
+			ia = constructor.get();
 		}
 		return ia;
 	}
-
-	/**
-	 * Creates an instance of IntegrityHmacMd5_128.
-	 *
-	 * @return An instance of {@code IntegrityHmacMd5_128}.
-	 * @throws IllegalArgumentException if the algorithm initiation fails.
-	 */
-	private IntegrityAlgorithm instantiateIntegrityHmacMd5128Algorithm() {
-		if (ia == null) {
-			try {
-				ia = new IntegrityHmacMd5_128();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
-		}
-		return ia;
-	}
-
-	/**
-	 * Creates an instance of IntegrityHmacSha256_128.
-	 *
-	 * @return An instance of {@code IntegrityHmacSha256_128}.
-	 * @throws IllegalArgumentException if the algorithm initiation fails.
-	 */
-	private IntegrityAlgorithm instantiateIntegrityHmacSha256128Algorithm() {
-		if (ia == null) {
-			try {
-				ia = new IntegrityHmacSha256_128();
-			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-			}
-		}
-		return ia;
-	}
+	
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
@@ -140,7 +140,7 @@ public class CipherSuite {
         }
     }
 
-	/**
+    /**
      * Returns instance of ConfidentialityAlgorithm class.
      *
      * @throws IllegalArgumentException
@@ -301,9 +301,9 @@ public class CipherSuite {
 	/**
 	 * Creates an instance of IntegrityHmacMd5_128.
 	 *
-     * @return An instance of {@code IntegrityHmacMd5_128}.
-     * @throws IllegalArgumentException if the algorithm initiation fails.
-     */
+	 * @return An instance of {@code IntegrityHmacMd5_128}.
+	 * @throws IllegalArgumentException if the algorithm initiation fails.
+	 */
 	private IntegrityAlgorithm instantiateIntegrityHmacMd5128Algorithm() {
         if (ia == null) {
             try {
@@ -319,9 +319,9 @@ public class CipherSuite {
 	/**
 	 * Creates an instance of IntegrityHmacSha256_128.
 	 *
-     * @return An instance of {@code IntegrityHmacSha256_128}.
-     * @throws IllegalArgumentException if the algorithm initiation fails.
-     */
+	 * @return An instance of {@code IntegrityHmacSha256_128}.
+	 * @throws IllegalArgumentException if the algorithm initiation fails.
+	 */
 	private IntegrityAlgorithm instantiateIntegrityHmacSha256128Algorithm() {
 		if (ia == null) {
             try {

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
@@ -26,6 +26,7 @@ import org.sentrysoftware.ipmi.core.coding.commands.session.GetChannelCipherSuit
 import org.sentrysoftware.ipmi.core.coding.commands.session.GetChannelCipherSuitesResponseData;
 import org.sentrysoftware.ipmi.core.common.TypeConverter;
 
+import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -245,5 +246,21 @@ public class CipherSuite {
 		}
 		return ia;
 	}
-	
+
+	/**
+	 * Constructs a Mac object that implements the given MAC algorithm.
+	 *
+	 * @param algorithmName the name of the algorithm to use
+	 * @return The Mac object that implements the specified MAC algorithm.
+	 */
+	public static Mac newMacInstance(final String algorithmName) {
+		if (algorithmName == null || algorithmName.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return Mac.getInstance(algorithmName);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("Algorithm " + algorithmName + " is not available", e);
+		}
+	}
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
@@ -230,63 +230,63 @@ public class CipherSuite {
         return new CipherSuite((byte) 0, (byte) 0, (byte) 0, (byte) 0);
     }
 
-    /**
-     * Creates an instance of AuthenticationRakpHmacSha1.
-     *
-     * @return An instance of {@code AuthenticationRakpHmacSha1}.
-     * @throws IllegalArgumentException if algorithm initialization fails.
-     */
-    private AuthenticationAlgorithm instantiateRakpHmacSha1Algorithm() {
-        if (aa == null) {
-            try {
-                aa = new AuthenticationRakpHmacSha1();
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-            }
-        }
-        return aa;
-    }
+	/**
+	 * Creates an instance of AuthenticationRakpHmacSha1.
+	 *
+	 * @return An instance of {@code AuthenticationRakpHmacSha1}.
+	 * @throws IllegalArgumentException if algorithm initialization fails.
+	 */
+	private AuthenticationAlgorithm instantiateRakpHmacSha1Algorithm() {
+		if (aa == null) {
+			try {
+				aa = new AuthenticationRakpHmacSha1();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
+		return aa;
+	}
 
-    /**
-     * Creates an instance of AuthenticationRakpHmacMd5.
-     *
-     * @return An instance of {@code AuthenticationRakpHmacMd5}.
-     * @throws IllegalArgumentException if algorithm initialization fails.
-     */
-    private AuthenticationAlgorithm instantiateRakpHmacMd5Algorithm() {
-        if (aa == null) {
-            try {
-                aa = new AuthenticationRakpHmacMd5();
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-            }
-        }
-        return aa;
-    }
+	/**
+	 * Creates an instance of AuthenticationRakpHmacMd5.
+	 *
+	 * @return An instance of {@code AuthenticationRakpHmacMd5}.
+	 * @throws IllegalArgumentException if algorithm initialization fails.
+	 */
+	private AuthenticationAlgorithm instantiateRakpHmacMd5Algorithm() {
+		if (aa == null) {
+			try {
+				aa = new AuthenticationRakpHmacMd5();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
+		return aa;
+	}
 
-    /**
-     * Creates an instance of AuthenticationRakpHmacSha256.
-     *
-     * @return An instance of {@code AuthenticationRakpHmacSha256}.
-     * @throws IllegalArgumentException if algorithm initialization fails.
-     */
-    private AuthenticationAlgorithm instantiateRakpHmacSha256Algorithm() {
-        if (aa == null) {
-            try {
-                aa = new AuthenticationRakpHmacSha256();
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
-            }
-        }
-        return aa;
-    }
+	/**
+	 * Creates an instance of AuthenticationRakpHmacSha256.
+	 *
+	 * @return An instance of {@code AuthenticationRakpHmacSha256}.
+	 * @throws IllegalArgumentException if algorithm initialization fails.
+	 */
+	private AuthenticationAlgorithm instantiateRakpHmacSha256Algorithm() {
+		if (aa == null) {
+			try {
+				aa = new AuthenticationRakpHmacSha256();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
+		return aa;
+	}
 
-    /**
-     * Creates an instance of IntegrityHmacSha1_96.
-     *
-     * @return An instance of {@code IntegrityHmacSha1_96}.
-     * @throws IllegalArgumentException if the algorithm initiation fails.
-     */
+	/**
+	 * Creates an instance of IntegrityHmacSha1_96.
+	 *
+	 * @return An instance of {@code IntegrityHmacSha1_96}.
+	 * @throws IllegalArgumentException if the algorithm initiation fails.
+	 */
 	private IntegrityAlgorithm instantiateIntegrityHmacSha196Algorithm() {
 		if (ia == null) {
 			try {
@@ -305,14 +305,13 @@ public class CipherSuite {
 	 * @throws IllegalArgumentException if the algorithm initiation fails.
 	 */
 	private IntegrityAlgorithm instantiateIntegrityHmacMd5128Algorithm() {
-        if (ia == null) {
-            try {
-                ia = new IntegrityHmacMd5_128();
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException(
-                        "Initiation of the algorithm failed", e);
-            }
-        }
+		if (ia == null) {
+			try {
+				ia = new IntegrityHmacMd5_128();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
 		return ia;
 	}
 
@@ -324,13 +323,12 @@ public class CipherSuite {
 	 */
 	private IntegrityAlgorithm instantiateIntegrityHmacSha256128Algorithm() {
 		if (ia == null) {
-            try {
-                ia = new IntegrityHmacSha256_128();
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException(
-                        "Initiation of the algorithm failed", e);
-            }
-        }
+			try {
+				ia = new IntegrityHmacSha256_128();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
 		return ia;
 	}
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/CipherSuite.java
@@ -78,7 +78,7 @@ public class CipherSuite {
      */
     public void initializeAlgorithms(byte[] sik) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
         getIntegrityAlgorithm().initialize(sik);
-        getConfidentialityAlgorithm().initialize(sik);
+        getConfidentialityAlgorithm().initialize(sik, getAuthenticationAlgorithm());
     }
 
     /**
@@ -99,25 +99,13 @@ public class CipherSuite {
             }
             return aa;
         case SecurityConstants.AA_RAKP_HMAC_SHA1:
-            if (aa == null) {
-                try {
-                    aa = new AuthenticationRakpHmacSha1();
-                } catch (NoSuchAlgorithmException e) {
-                    throw new IllegalArgumentException(
-                            "Initiation of the algorithm failed", e);
-                }
-            }
-            return aa;
+            return instantiateRakpHmacSha1Algorithm();
         case SecurityConstants.AA_RAKP_HMAC_MD5:
-            // TODO: RAKP HMAC MD5
-            throw new IllegalArgumentException(NOT_YET_IMPLEMENTED_MESSAGE);
+            return instantiateRakpHmacMd5Algorithm();
         case SecurityConstants.AA_RAKP_HMAC_SHA256:
-            // TODO: RAKP HMAC Sha256
-            throw new IllegalArgumentException(NOT_YET_IMPLEMENTED_MESSAGE);
+            return instantiateRakpHmacSha256Algorithm();
         default:
-            throw new IllegalArgumentException(
-                    "Invalid authentication algorithm.");
-
+            throw new IllegalArgumentException("Invalid authentication algorithm.");
         }
     }
 
@@ -127,7 +115,7 @@ public class CipherSuite {
      * @throws IllegalArgumentException
      *             when integrity algorithm code is incorrect.
      */
-    public IntegrityAlgorithm getIntegrityAlgorithm() {
+    public IntegrityAlgorithm getIntegrityAlgorithm(){
         if (ia != null && ia.getCode() != integrityAlgorithm) {
             throw new IllegalArgumentException(
                     "Invalid integrity algorithm code");
@@ -139,31 +127,20 @@ public class CipherSuite {
             }
             return ia;
         case SecurityConstants.IA_HMAC_SHA1_96:
-            if (ia == null) {
-                try {
-                    ia = new IntegrityHmacSha1_96();
-                } catch (NoSuchAlgorithmException e) {
-                    throw new IllegalArgumentException(
-                            "Initiation of the algorithm failed", e);
-                }
-            }
-            return ia;
-        case SecurityConstants.IA_HMAC_SHA256_128:
-            // TODO: HMAC SHA256-128
-            throw new IllegalArgumentException(NOT_YET_IMPLEMENTED_MESSAGE);
+            return instantiateIntegrityHmacSha196Algorithm();
         case SecurityConstants.IA_MD5_128:
             // TODO: MD5-128
-            throw new IllegalArgumentException(NOT_YET_IMPLEMENTED_MESSAGE);
         case SecurityConstants.IA_HMAC_MD5_128:
-            // TODO: HMAC MD5-128
-            throw new IllegalArgumentException(NOT_YET_IMPLEMENTED_MESSAGE);
+            return instantiateIntegrityHmacMd5128Algorithm();
+        case SecurityConstants.IA_HMAC_SHA256_128:
+            return instantiateIntegrityHmacSha256128Algorithm();
         default:
             throw new IllegalArgumentException("Invalid integrity algorithm.");
 
         }
     }
 
-    /**
+	/**
      * Returns instance of ConfidentialityAlgorithm class.
      *
      * @throws IllegalArgumentException
@@ -252,4 +229,108 @@ public class CipherSuite {
     public static CipherSuite getEmpty() {
         return new CipherSuite((byte) 0, (byte) 0, (byte) 0, (byte) 0);
     }
+
+    /**
+     * Creates an instance of AuthenticationRakpHmacSha1.
+     *
+     * @return An instance of {@code AuthenticationRakpHmacSha1}.
+     * @throws IllegalArgumentException if algorithm initialization fails.
+     */
+    private AuthenticationAlgorithm instantiateRakpHmacSha1Algorithm() {
+        if (aa == null) {
+            try {
+                aa = new AuthenticationRakpHmacSha1();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+            }
+        }
+        return aa;
+    }
+
+    /**
+     * Creates an instance of AuthenticationRakpHmacMd5.
+     *
+     * @return An instance of {@code AuthenticationRakpHmacMd5}.
+     * @throws IllegalArgumentException if algorithm initialization fails.
+     */
+    private AuthenticationAlgorithm instantiateRakpHmacMd5Algorithm() {
+        if (aa == null) {
+            try {
+                aa = new AuthenticationRakpHmacMd5();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+            }
+        }
+        return aa;
+    }
+
+    /**
+     * Creates an instance of AuthenticationRakpHmacSha256.
+     *
+     * @return An instance of {@code AuthenticationRakpHmacSha256}.
+     * @throws IllegalArgumentException if algorithm initialization fails.
+     */
+    private AuthenticationAlgorithm instantiateRakpHmacSha256Algorithm() {
+        if (aa == null) {
+            try {
+                aa = new AuthenticationRakpHmacSha256();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+            }
+        }
+        return aa;
+    }
+
+    /**
+     * Creates an instance of IntegrityHmacSha1_96.
+     *
+     * @return An instance of {@code IntegrityHmacSha1_96}.
+     * @throws IllegalArgumentException if the algorithm initiation fails.
+     */
+	private IntegrityAlgorithm instantiateIntegrityHmacSha196Algorithm() {
+		if (ia == null) {
+			try {
+				ia = new IntegrityHmacSha1_96();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalArgumentException("Initiation of the algorithm failed", e);
+			}
+		}
+		return ia;
+	}
+
+	/**
+	 * Creates an instance of IntegrityHmacMd5_128.
+	 *
+     * @return An instance of {@code IntegrityHmacMd5_128}.
+     * @throws IllegalArgumentException if the algorithm initiation fails.
+     */
+	private IntegrityAlgorithm instantiateIntegrityHmacMd5128Algorithm() {
+        if (ia == null) {
+            try {
+                ia = new IntegrityHmacMd5_128();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalArgumentException(
+                        "Initiation of the algorithm failed", e);
+            }
+        }
+		return ia;
+	}
+
+	/**
+	 * Creates an instance of IntegrityHmacSha256_128.
+	 *
+     * @return An instance of {@code IntegrityHmacSha256_128}.
+     * @throws IllegalArgumentException if the algorithm initiation fails.
+     */
+	private IntegrityAlgorithm instantiateIntegrityHmacSha256128Algorithm() {
+		if (ia == null) {
+            try {
+                ia = new IntegrityHmacSha256_128();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalArgumentException(
+                        "Initiation of the algorithm failed", e);
+            }
+        }
+		return ia;
+	}
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
@@ -58,9 +58,10 @@ public class ConfidentialityAesCbc128 extends ConfidentialityAlgorithm {
             NoSuchAlgorithmException, NoSuchPaddingException {
         super.initialize(sik, authenticationAlgorithm);
 
-        SecretKeySpec k2 = new SecretKeySpec(sik, authenticationAlgorithm.getAlgorithmName());
+        final String algorithmName = authenticationAlgorithm.getAlgorithmName();
+		SecretKeySpec k2 = new SecretKeySpec(sik, algorithmName);
 
-        Mac mac = Mac.getInstance(authenticationAlgorithm.getAlgorithmName());
+        Mac mac = Mac.getInstance(algorithmName);
         mac.init(k2);
 
         byte[] ckey = mac.doFinal(CONST2);

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
@@ -51,13 +51,13 @@ public class ConfidentialityAesCbc128 extends ConfidentialityAlgorithm {
     }
 
     @Override
-    public void initialize(byte[] sik) throws InvalidKeyException,
+    public void initialize(byte[] sik, AuthenticationAlgorithm authenticationAlgorithm) throws InvalidKeyException,
             NoSuchAlgorithmException, NoSuchPaddingException {
-        super.initialize(sik);
+        super.initialize(sik, authenticationAlgorithm);
 
-        SecretKeySpec k2 = new SecretKeySpec(sik, "HmacSHA1");
+        SecretKeySpec k2 = new SecretKeySpec(sik, authenticationAlgorithm.getAlgorithmName());
 
-        Mac mac = Mac.getInstance("HmacSHA1");
+        Mac mac = Mac.getInstance(authenticationAlgorithm.getAlgorithmName());
         mac.init(k2);
 
         byte[] ckey = mac.doFinal(CONST2);

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAesCbc128.java
@@ -24,6 +24,7 @@ package org.sentrysoftware.ipmi.core.coding.security;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
@@ -38,8 +39,10 @@ import org.sentrysoftware.ipmi.core.common.TypeConverter;
  */
 public class ConfidentialityAesCbc128 extends ConfidentialityAlgorithm {
 
-    private static final byte[] CONST2 = new byte[] { 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+	protected static final byte[] CONST2 = new byte[20];
+	static {
+		Arrays.fill(CONST2, (byte) 2);
+	}
 
     private Cipher cipher;
 

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/ConfidentialityAlgorithm.java
@@ -39,6 +39,8 @@ public abstract class ConfidentialityAlgorithm {
      * @param sik
      *            - Session Integrity Key calculated during the opening of the
      *            session or user password if 'one-key' logins are enabled.
+     * @param authenticationAlgorithm
+     *           - Algorithm used for authentication.
      * @throws InvalidKeyException
      *             - when initiation of the algorithm fails
      * @throws NoSuchAlgorithmException
@@ -46,7 +48,7 @@ public abstract class ConfidentialityAlgorithm {
      * @throws NoSuchPaddingException
      *             - when initiation of the algorithm fails
      */
-    public void initialize(byte[] sik) throws InvalidKeyException,
+    public void initialize(byte[] sik, AuthenticationAlgorithm authenticationAlgorithm) throws InvalidKeyException,
             NoSuchAlgorithmException, NoSuchPaddingException {
         this.sik = sik;
     }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityAlgorithm.java
@@ -50,7 +50,7 @@ public abstract class IntegrityAlgorithm {
 	 * Constructs an integrity algorithm.
 	 */
 	protected IntegrityAlgorithm(String algorithmName) {
-		this(newMacInstance(algorithmName));
+		this(CipherSuite.newMacInstance(algorithmName));
 	}
 
 	/**
@@ -60,23 +60,6 @@ public abstract class IntegrityAlgorithm {
 	 */
 	private IntegrityAlgorithm(Mac mac) {
 		this.mac = mac;
-	}
-
-	/**
-	 * Constructs a Mac object that implements the given MAC algorithm.
-	 * 
-	 * @param algorithmName the name of the algorithm to use
-	 * @return The Mac object that implements the specified MAC algorithm. 
-	 */
-	private static Mac newMacInstance(final String algorithmName) {
-		if (algorithmName == null || algorithmName.trim().isEmpty()) {
-			return null;
-		}
-		try {
-			return Mac.getInstance(algorithmName);
-		} catch (NoSuchAlgorithmException e) {
-			throw new IllegalArgumentException("Algorithm " + algorithmName + " is not available", e);
-		}
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityAlgorithm.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityAlgorithm.java
@@ -39,6 +39,10 @@ public abstract class IntegrityAlgorithm {
 
     }
 
+    protected static final byte[] CONST1 = new byte[] {
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,1
+    };
+
     /**
      * Initializes Integrity Algorithm
      *

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
@@ -53,8 +53,7 @@ public class IntegrityHmacMd5_128 extends IntegrityAlgorithm {
         SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
 
         mac.init(k1);
-        byte[] derivedKey = mac.doFinal(CONST1);
-        k1 = new SecretKeySpec(derivedKey, ALGORITHM_NAME);
+        k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
 
         mac.init(k1);
     }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
@@ -33,11 +33,9 @@ public class IntegrityHmacMd5_128 extends IntegrityAlgorithm {
 
 	/**
 	 * Initiates HMAC-MD5-128 integrity algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
 	 */
-	public IntegrityHmacMd5_128() throws NoSuchAlgorithmException {
-		super();
+	public IntegrityHmacMd5_128() {
+		super(ALGORITHM_NAME);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
@@ -1,10 +1,5 @@
 package org.sentrysoftware.ipmi.core.coding.security;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client
@@ -27,22 +22,28 @@ import javax.crypto.spec.SecretKeySpec;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-/**
- * HMAC-SHA1-96 integrity algorithm.
- */
-public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
-    public static final String ALGORITHM_NAME = "HmacSHA1";
+/**
+ * HMAC-MD5-128 integrity algorithm.
+ */
+public class IntegrityHmacMd5_128 extends IntegrityAlgorithm {
+
+    public static final String ALGORITHM_NAME = "HmacMD5";
     private Mac mac;
 
     /**
-     * Initiates HMAC-SHA1-96 integrity algorithm.
+     * Initiates HMAC-MD5-128 integrity algorithm.
      *
      * @throws NoSuchAlgorithmException
      *             - when initiation of the algorithm fails
      */
-    public IntegrityHmacSha1_96() throws NoSuchAlgorithmException {
+    public IntegrityHmacMd5_128() throws NoSuchAlgorithmException {
         mac = Mac.getInstance(ALGORITHM_NAME);
+
     }
 
     @Override
@@ -60,7 +61,7 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
 
     @Override
     public byte getCode() {
-        return SecurityConstants.IA_HMAC_SHA1_96;
+        return SecurityConstants.IA_HMAC_MD5_128;
     }
 
     @Override
@@ -69,18 +70,17 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
             throw new NullPointerException("Algorithm not initialized.");
         }
 
-        byte[] result = new byte[12];
+        byte[] result = new byte[16];
         byte[] updatedBase;
 
         if(base[base.length - 2] == 0 /*there are no integrity pad bytes*/) {
-            updatedBase = injectIntegrityPad(base,12);
+            updatedBase = injectIntegrityPad(base,16);
         } else {
             updatedBase = base;
         }
 
-        System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 12);
+        System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 16);
 
         return result;
     }
-
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * HMAC-MD5-128 integrity algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacMd5_128.java
@@ -22,9 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 /**
@@ -32,54 +29,29 @@ import java.security.NoSuchAlgorithmException;
  */
 public class IntegrityHmacMd5_128 extends IntegrityAlgorithm {
 
-    public static final String ALGORITHM_NAME = "HmacMD5";
-    private Mac mac;
+	public static final String ALGORITHM_NAME = "HmacMD5";
 
-    /**
-     * Initiates HMAC-MD5-128 integrity algorithm.
-     *
-     * @throws NoSuchAlgorithmException
-     *             - when initiation of the algorithm fails
-     */
-    public IntegrityHmacMd5_128() throws NoSuchAlgorithmException {
-        mac = Mac.getInstance(ALGORITHM_NAME);
+	/**
+	 * Initiates HMAC-MD5-128 integrity algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException - when initiation of the algorithm fails
+	 */
+	public IntegrityHmacMd5_128() throws NoSuchAlgorithmException {
+		super();
+	}
 
-    }
+	@Override
+	public byte getCode() {
+		return SecurityConstants.IA_HMAC_MD5_128;
+	}
 
-    @Override
-    public void initialize(byte[] sik) throws InvalidKeyException {
-        super.initialize(sik);
+	@Override
+	public String getAlgorithmName() {
+		return ALGORITHM_NAME;
+	}
 
-        SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
-
-        mac.init(k1);
-        k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
-
-        mac.init(k1);
-    }
-
-    @Override
-    public byte getCode() {
-        return SecurityConstants.IA_HMAC_MD5_128;
-    }
-
-    @Override
-    public byte[] generateAuthCode(final byte[] base) {
-        if (sik == null) {
-            throw new NullPointerException("Algorithm not initialized.");
-        }
-
-        byte[] result = new byte[16];
-        byte[] updatedBase;
-
-        if(base[base.length - 2] == 0 /*there are no integrity pad bytes*/) {
-            updatedBase = injectIntegrityPad(base,16);
-        } else {
-            updatedBase = base;
-        }
-
-        System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 16);
-
-        return result;
-    }
+	@Override
+	public int getAuthCodeLength() {
+		return 16;
+	}
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
@@ -33,12 +33,9 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
 
     /**
      * Initiates HMAC-SHA1-96 integrity algorithm.
-     *
-     * @throws NoSuchAlgorithmException
-     *             - when initiation of the algorithm fails
      */
-    public IntegrityHmacSha1_96() throws NoSuchAlgorithmException {
-        super();
+    public IntegrityHmacSha1_96() {
+        super(ALGORITHM_NAME);
     }
 
     @Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
@@ -1,10 +1,5 @@
 package org.sentrysoftware.ipmi.core.coding.security;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client
@@ -26,6 +21,11 @@ import javax.crypto.spec.SecretKeySpec;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * HMAC-SHA1-96 integrity algorithm.

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * HMAC-SHA1-96 integrity algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
@@ -52,8 +52,7 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
         SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
 
         mac.init(k1);
-        byte[] derivedKey = mac.doFinal(CONST1);
-        k1 = new SecretKeySpec(derivedKey, ALGORITHM_NAME);
+        k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
 
         mac.init(k1);
     }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha1_96.java
@@ -22,10 +22,7 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * HMAC-SHA1-96 integrity algorithm.
@@ -33,7 +30,6 @@ import javax.crypto.spec.SecretKeySpec;
 public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
 
     public static final String ALGORITHM_NAME = "HmacSHA1";
-    private Mac mac;
 
     /**
      * Initiates HMAC-SHA1-96 integrity algorithm.
@@ -42,19 +38,7 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
      *             - when initiation of the algorithm fails
      */
     public IntegrityHmacSha1_96() throws NoSuchAlgorithmException {
-        mac = Mac.getInstance(ALGORITHM_NAME);
-    }
-
-    @Override
-    public void initialize(byte[] sik) throws InvalidKeyException {
-        super.initialize(sik);
-
-        SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
-
-        mac.init(k1);
-        k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
-
-        mac.init(k1);
+        super();
     }
 
     @Override
@@ -63,23 +47,12 @@ public class IntegrityHmacSha1_96 extends IntegrityAlgorithm {
     }
 
     @Override
-    public byte[] generateAuthCode(final byte[] base) {
-        if (sik == null) {
-            throw new NullPointerException("Algorithm not initialized.");
-        }
-
-        byte[] result = new byte[12];
-        byte[] updatedBase;
-
-        if(base[base.length - 2] == 0 /*there are no integrity pad bytes*/) {
-            updatedBase = injectIntegrityPad(base,12);
-        } else {
-            updatedBase = base;
-        }
-
-        System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 12);
-
-        return result;
+    public String getAlgorithmName() {
+        return ALGORITHM_NAME;
     }
-
+    
+	@Override
+	public int getAuthCodeLength() {
+	    return 12;
+	}
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -1,0 +1,86 @@
+package org.sentrysoftware.ipmi.core.coding.security;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * IPMI Java Client
+ * ჻჻჻჻჻჻
+ * Copyright 2023 Verax Systems, Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * HMAC-SHA256-128 integrity algorithm.
+ */
+public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
+
+	private static final String ALGORITHM_NAME = "HmacSHA256";
+	private Mac mac;
+
+	/**
+	 * Initiates HMAC-SHA1-96 integrity algorithm.
+	 *
+	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
+	 */
+	public IntegrityHmacSha256_128() throws NoSuchAlgorithmException {
+		mac = Mac.getInstance(ALGORITHM_NAME);
+	}
+
+	@Override
+	public void initialize(byte[] sik) throws InvalidKeyException {
+		super.initialize(sik);
+
+		SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
+
+		mac.init(k1);
+		byte[] derivedKey = mac.doFinal(CONST1);
+		k1 = new SecretKeySpec(derivedKey, ALGORITHM_NAME);
+
+		mac.init(k1);
+	}
+
+	@Override
+	public byte getCode() {
+		return SecurityConstants.IA_HMAC_SHA256_128;
+	}
+
+	@Override
+	public byte[] generateAuthCode(byte[] base) {
+
+		if (sik == null) {
+			throw new NullPointerException("Algorithm not initialized.");
+		}
+
+		byte[] result = new byte[16];
+		byte[] updatedBase;
+
+		if (base[base.length - 2] == 0 /* there are no integrity pad bytes */) {
+			updatedBase = injectIntegrityPad(base, 16);
+		} else {
+			updatedBase = base;
+		}
+
+		System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 16);
+
+		return result;
+	}
+
+}

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -33,11 +33,9 @@ public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
 
 	/**
 	 * Initiates HMAC-SHA1-96 integrity algorithm.
-	 *
-	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
 	 */
-	public IntegrityHmacSha256_128() throws NoSuchAlgorithmException {
-		super();
+	public IntegrityHmacSha256_128() {
+		super(ALGORITHM_NAME);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -22,10 +22,7 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * HMAC-SHA256-128 integrity algorithm.
@@ -33,7 +30,6 @@ import javax.crypto.spec.SecretKeySpec;
 public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
 
 	private static final String ALGORITHM_NAME = "HmacSHA256";
-	private Mac mac;
 
 	/**
 	 * Initiates HMAC-SHA1-96 integrity algorithm.
@@ -41,19 +37,7 @@ public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
 	 * @throws NoSuchAlgorithmException when initiation of the algorithm fails
 	 */
 	public IntegrityHmacSha256_128() throws NoSuchAlgorithmException {
-		mac = Mac.getInstance(ALGORITHM_NAME);
-	}
-
-	@Override
-	public void initialize(byte[] sik) throws InvalidKeyException {
-		super.initialize(sik);
-
-		SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
-
-		mac.init(k1);
-		k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
-
-		mac.init(k1);
+		super();
 	}
 
 	@Override
@@ -62,24 +46,13 @@ public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
 	}
 
 	@Override
-	public byte[] generateAuthCode(byte[] base) {
+	public String getAlgorithmName() {
+		return ALGORITHM_NAME;
+	}
 
-		if (sik == null) {
-			throw new NullPointerException("Algorithm not initialized.");
-		}
-
-		byte[] result = new byte[16];
-		byte[] updatedBase;
-
-		if (base[base.length - 2] == 0 /* there are no integrity pad bytes */) {
-			updatedBase = injectIntegrityPad(base, 16);
-		} else {
-			updatedBase = base;
-		}
-
-		System.arraycopy(mac.doFinal(updatedBase), 0, result, 0, 16);
-
-		return result;
+	@Override
+	public int getAuthCodeLength() {
+		return 16;
 	}
 
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -22,8 +22,6 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * HMAC-SHA256-128 integrity algorithm.
  */

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -51,8 +51,7 @@ public class IntegrityHmacSha256_128 extends IntegrityAlgorithm {
 		SecretKeySpec k1 = new SecretKeySpec(sik, ALGORITHM_NAME);
 
 		mac.init(k1);
-		byte[] derivedKey = mac.doFinal(CONST1);
-		k1 = new SecretKeySpec(derivedKey, ALGORITHM_NAME);
+		k1 = new SecretKeySpec(mac.doFinal(CONST1), ALGORITHM_NAME);
 
 		mac.init(k1);
 	}

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityHmacSha256_128.java
@@ -1,10 +1,5 @@
 package org.sentrysoftware.ipmi.core.coding.security;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client
@@ -26,6 +21,11 @@ import javax.crypto.spec.SecretKeySpec;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * HMAC-SHA256-128 integrity algorithm.

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
@@ -29,8 +29,11 @@ import java.security.InvalidKeyException;
  */
 public class IntegrityNone extends IntegrityAlgorithm {
 
+	/**
+	 * Initiates the IntegrityNone algorithm
+	 */
 	public IntegrityNone() {
-		super(true);
+		super("");
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
@@ -22,23 +22,40 @@ package org.sentrysoftware.ipmi.core.coding.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.security.InvalidKeyException;
+
 /**
  * Class representing RAKP-None integrity algorithm
  */
 public class IntegrityNone extends IntegrityAlgorithm {
 
-    public IntegrityNone() {
-        super();
-    }
+	public IntegrityNone() {
+		super(true);
+	}
 
-    @Override
-    public byte getCode() {
-        return SecurityConstants.IA_NONE;
-    }
+	@Override
+	public void initialize(byte[] sik) throws InvalidKeyException {
+		this.sik = sik;
+	}
 
-    @Override
-    public byte[] generateAuthCode(byte[] base) {
-        return null;
-    }
+	@Override
+	public byte getCode() {
+		return SecurityConstants.IA_NONE;
+	}
+
+	@Override
+	public byte[] generateAuthCode(byte[] base) {
+		return new byte[0];
+	}
+
+	@Override
+	public String getAlgorithmName() {
+		return "";
+	}
+
+	@Override
+	public int getAuthCodeLength() {
+		return 0;
+	}
 
 }

--- a/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/coding/security/IntegrityNone.java
@@ -45,7 +45,7 @@ public class IntegrityNone extends IntegrityAlgorithm {
 
 	@Override
 	public byte[] generateAuthCode(byte[] base) {
-		return new byte[0];
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/ipmi/core/connection/Connection.java
+++ b/src/main/java/org/sentrysoftware/ipmi/core/connection/Connection.java
@@ -665,17 +665,14 @@ public class Connection extends TimerTask implements MachineObserver {
         return result;
     }
 
-    /**
-     * @return Default cipher suite (3)
-     */
-    public static CipherSuite getDefaultCipherSuite() {
-        try {
-            return new CipherSuite((byte) DEFAULT_CIPHER_SUITE, new AuthenticationRakpHmacSha1().getCode(),
-                    new ConfidentialityAesCbc128().getCode(), new IntegrityHmacSha1_96().getCode());
-        } catch (NoSuchAlgorithmException e) {
-            logger.error("Wrong algorithm in default Cipher suite - SHOULD NOT HAPPEN!!!", e);
-            return null;
-        }
-    }
+	/**
+	 * @return Default cipher suite (3)
+	 */
+	public static CipherSuite getDefaultCipherSuite() {
+
+		return new CipherSuite((byte) DEFAULT_CIPHER_SUITE, new AuthenticationRakpHmacSha1().getCode(),
+				new ConfidentialityAesCbc128().getCode(), new IntegrityHmacSha1_96().getCode());
+
+	}
 
 }


### PR DESCRIPTION
* Added AuthenticationRakpHmacMd5, AuthenticationRakpHmacSha256, IntegrityHmacMd5_128, and IntegrityHmacSha256_128.

* Updated CipherSuite, ConfidentialityAesCbc128, ConfidentialityAlgorithm, AuthenticationRakpNone, AuthenticatioRakpHmacSha1, IntegrityAlgorithm, AuthenticationAlgorithm,  and IntegrityHmacSha1_96.  

### Tested :
#### HmacSH256 :
![Capture d'écran 2025-02-04 152036](https://github.com/user-attachments/assets/0155e7c4-e533-40e3-9362-baaa2b3cd1b6)
 ![Capture d'écran 2025-02-04 153039](https://github.com/user-attachments/assets/aed05bee-b6b8-44b5-9836-36b07a2aedea)


#### HmacMd5 :
![Capture d'écran 2025-02-04 175551](https://github.com/user-attachments/assets/06367a4e-647f-41d7-b720-b39b00c403e2)
![Capture d'écran 2025-02-04 174753](https://github.com/user-attachments/assets/03362716-54ab-4ef8-9cbd-1d82ea244792)

